### PR TITLE
use systemd to provision cache and logs directory

### DIFF
--- a/peroxide.service
+++ b/peroxide.service
@@ -9,6 +9,10 @@ ExecStart=/usr/sbin/peroxide -log-file=/var/log/peroxide/peroxide.log -log-level
 User=peroxide
 Group=peroxide
 ExecReload=/bin/kill -HUP $MAINPID
+CacheDirectory=peroxide peroxide/cache
+CacheDirectoryMode=0700
+LogsDirectory=peroxide
+LogsDirectoryMode=0750
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently the install script creates these directories which is fine, but if we let `systemd` handle directory creation then `systemd` will always ensure the directories: exist, have proper ownership, and proper permissions **every** time the service starts.